### PR TITLE
Add bulk markdown download for search results

### DIFF
--- a/src/components/MasterDetailView.tsx
+++ b/src/components/MasterDetailView.tsx
@@ -1,7 +1,18 @@
-import { Calendar, ChevronLeft, PanelLeft, PanelLeftClose, Search, X } from "lucide-react";
+import { saveAs } from "file-saver";
+import {
+  Calendar,
+  Check,
+  ChevronLeft,
+  Download,
+  PanelLeft,
+  PanelLeftClose,
+  Search,
+  X,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { findSearchMatches, type SearchMatch } from "../lib/searchUtils";
+import { chatsToMarkdownZip } from "../lib/utils";
 import type { ChatData } from "../schemas/chat";
 import { sortConversations, type SortField, type SortOrder } from "../utils/sorting";
 
@@ -27,6 +38,8 @@ export const MasterDetailView: React.FC<MasterDetailViewProps> = ({
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [sortField, setSortField] = useState<SortField>("updated_at");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [downloadSuccess, setDownloadSuccess] = useState(false);
 
   // Auto-collapse sidebar on mobile by default
   useEffect(() => {
@@ -137,6 +150,28 @@ export const MasterDetailView: React.FC<MasterDetailViewProps> = ({
     return { filteredConversations: filtered, searchMatches: matchesMap };
   })();
 
+  // Download all currently-listed conversations (filtered when searching, otherwise all)
+  // as a ZIP of individual markdown files.
+  const handleDownloadAllMarkdown = async () => {
+    if (filteredConversations.length === 0 || isDownloading) return;
+
+    setIsDownloading(true);
+    try {
+      const blob = await chatsToMarkdownZip(filteredConversations);
+      const zipName = searchQuery.trim()
+        ? "claude-conversations-search.zip"
+        : "claude-conversations.zip";
+      saveAs(blob, zipName);
+
+      setDownloadSuccess(true);
+      setTimeout(() => setDownloadSuccess(false), 2000);
+    } catch (err) {
+      console.error("Failed to download conversations as markdown:", err);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
   return (
     <div className="flex h-screen bg-gray-50">
       {/* Sidebar */}
@@ -166,6 +201,29 @@ export const MasterDetailView: React.FC<MasterDetailViewProps> = ({
             <h2 className="font-semibold text-sm text-gray-900">
               Conversations ({filteredConversations.length} of {conversations.length})
             </h2>
+
+            {/* Download all listed conversations as markdown */}
+            <Button
+              onClick={handleDownloadAllMarkdown}
+              variant="outline"
+              size="sm"
+              disabled={filteredConversations.length === 0 || isDownloading}
+              className="w-full"
+            >
+              {downloadSuccess ? (
+                <>
+                  <Check className="h-4 w-4 mr-2" />
+                  Downloaded
+                </>
+              ) : (
+                <>
+                  <Download className="h-4 w-4 mr-2" />
+                  {isDownloading
+                    ? "Preparing…"
+                    : `Download ${filteredConversations.length} as Markdown`}
+                </>
+              )}
+            </Button>
 
             {/* Search Bar */}
             <div className="relative">

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,6 +1,7 @@
+import JSZip from "jszip";
 import { describe, expect, it } from "bun:test";
 import type { ChatData } from "../schemas/chat";
-import { chatToHtml, chatToText, formatValidationErrors } from "./utils";
+import { chatsToMarkdownZip, chatToHtml, chatToText, formatValidationErrors } from "./utils";
 
 describe.skip("formatValidationErrors", () => {
   it("should add line numbers to validation errors", () => {
@@ -95,6 +96,71 @@ describe("chatToText", () => {
     expect(result).toBe(
       "Human:\nHello\nHow are you?\n\nClaude:\nI'm fine, thank you!\nprint('hi')\n",
     );
+  });
+});
+
+describe("chatsToMarkdownZip", () => {
+  const makeChat = (uuid: string, name: string): ChatData => ({
+    name,
+    uuid,
+    summary: "",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    chat_messages: [
+      {
+        uuid: `${uuid}-msg1`,
+        sender: "human",
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+        index: 0,
+        text: "Hello",
+        truncated: false,
+        content: [{ type: "text", text: "Hello" }],
+      },
+    ],
+  });
+
+  it("should create one markdown entry per conversation", async () => {
+    const chats = [makeChat("a", "First Chat"), makeChat("b", "Second Chat")];
+
+    const blob = await chatsToMarkdownZip(chats);
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+    const names = Object.keys(zip.files);
+
+    expect(names).toHaveLength(2);
+  });
+
+  it("should write each conversation's markdown into its entry", async () => {
+    const chats = [makeChat("a", "First Chat")];
+
+    const blob = await chatsToMarkdownZip(chats);
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+    const entry = zip.files["first_chat.md"];
+
+    expect(entry).toBeDefined();
+    const content = await entry.async("string");
+    expect(content).toContain("# First Chat");
+    expect(content).toContain("Hello");
+  });
+
+  it("should disambiguate entries when conversation names collide", async () => {
+    const chats = [makeChat("a", "Same Name"), makeChat("b", "Same Name")];
+
+    const blob = await chatsToMarkdownZip(chats);
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+    const names = Object.keys(zip.files).sort();
+
+    expect(names).toEqual(["same_name-2.md", "same_name.md"]);
+  });
+
+  it("should fall back to a default name for untitled conversations", async () => {
+    const chats = [makeChat("a", "")];
+
+    const blob = await chatsToMarkdownZip(chats);
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+    const names = Object.keys(zip.files);
+
+    expect(names).toEqual(["untitled-conversation.md"]);
   });
 });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -263,6 +263,35 @@ export function chatToMarkdown(data: ChatData, options: MarkdownOptions = {}): s
   return markdown;
 }
 
+// Build a filesystem-safe base name for a conversation's markdown file.
+function conversationFileBaseName(data: ChatData): string {
+  const sanitized = (data.name || "").replace(/[^a-z0-9-]/gi, "_").toLowerCase();
+  const trimmed = sanitized.replace(/^_+|_+$/g, "");
+  return trimmed || "untitled-conversation";
+}
+
+// Bundle multiple conversations into a single ZIP, one markdown file per conversation.
+// Names that would collide are disambiguated with a numeric suffix so no entry is lost.
+export async function chatsToMarkdownZip(
+  conversations: ChatData[],
+  options: MarkdownOptions = {},
+): Promise<Blob> {
+  const JSZip = (await import("jszip")).default;
+  const zip = new JSZip();
+  const usedNames = new Map<string, number>();
+
+  conversations.forEach((conversation) => {
+    const base = conversationFileBaseName(conversation);
+    const count = usedNames.get(base) ?? 0;
+    usedNames.set(base, count + 1);
+    const fileName = count === 0 ? `${base}.md` : `${base}-${count + 1}.md`;
+
+    zip.file(fileName, chatToMarkdown(conversation, options));
+  });
+
+  return zip.generateAsync({ type: "blob" });
+}
+
 export function formatValidationErrors(
   json: string,
   errors: Array<{ path: string; message: string }>,


### PR DESCRIPTION
## Summary

Adds a **bulk "Download as Markdown"** action to the conversation list / search sidebar. It exports every currently-listed conversation — all of them, or just the matches when a search query is active — as a ZIP of individual `.md` files. This extends the existing single-conversation markdown export to work across the whole (filtered) list.

## What changed

- **`src/lib/utils.ts`** — new `chatsToMarkdownZip(conversations, options?)`:
  - Lazy-loads JSZip (same pattern as the existing artifact export), so it's only pulled in on demand.
  - Renders each conversation with the existing `chatToMarkdown()`.
  - Derives each entry's filename from the conversation name using the same sanitization convention already used by the artifact export, falling back to `untitled-conversation`.
  - Disambiguates colliding names with a numeric suffix (`-2`, `-3`, …) so no entry is silently overwritten.
- **`src/components/MasterDetailView.tsx`** — a "Download N as Markdown" button under the *Conversations (X of Y)* heading:
  - The count reflects the filtered list; the button is disabled when the list is empty.
  - Shows a "Preparing…" state while zipping and a brief "Downloaded" confirmation on success.
  - Saves `claude-conversations-search.zip` when a search is active, otherwise `claude-conversations.zip`.
  - Uses the default export options (thinking off, artifacts on, colophon on).

## Testing

- New unit tests in `src/lib/utils.test.ts` cover entry count, per-entry markdown content, collision suffixing, and the untitled fallback.
- `bun test` passes for the new tests; `typecheck`, `biome lint`, and `vite build` all pass.
- Manually verified in the browser: loading a 2-conversation export shows "Download 2 as Markdown"; searching narrows the count to 1 and the button updates accordingly; clicking produces a valid ZIP with no console errors.