### PR TITLE
feat: filter conversations by user in organization exports

### DIFF
--- a/src/components/Artifact.tsx
+++ b/src/components/Artifact.tsx
@@ -2,9 +2,9 @@ import { useState } from "react";
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
-  SheetDescription,
 } from "@/components/ui/sheet";
 
 interface ArtifactProps {

--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -951,6 +951,7 @@ const ChatViewer: React.FC = () => {
   const [isNavigating, setIsNavigating] = useState(false);
   const [useMasterDetail] = useState(true); // Default to master-detail view
   const [userMap, setUserMap] = useState<UserMap | null>(null);
+  const [loadKey, setLoadKey] = useState(0);
 
   // Update URL to reflect current state
   const updateURL = (
@@ -990,8 +991,13 @@ const ChatViewer: React.FC = () => {
     updateURL("view", data.uuid);
   };
 
-  const handleConversationList = (conversations: ChatData[], warning?: string, newUserMap?: UserMap) => {
+  const handleConversationList = (
+    conversations: ChatData[],
+    warning?: string,
+    newUserMap?: UserMap,
+  ) => {
     setUserMap(newUserMap ?? null);
+    setLoadKey((k) => k + 1);
     setConversationList(conversations);
 
     if (warning) {
@@ -1509,6 +1515,7 @@ const ChatViewer: React.FC = () => {
               )}
               <div className="flex-1 overflow-hidden">
                 <MasterDetailView
+                  key={loadKey}
                   conversations={conversationList}
                   selectedConversation={chatData}
                   onSelectConversation={(conversation) => {
@@ -1524,6 +1531,7 @@ const ChatViewer: React.FC = () => {
             </div>
           ) : activeTab === "browse" && conversationList ? (
             <ConversationBrowser
+              key={loadKey}
               conversations={conversationList}
               onSelectConversation={handleSelectFromBrowser}
               onBack={handleBackToInput}

--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -5,7 +5,7 @@ import { lazy, Suspense, useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { parseMessage } from "../lib/messageParser";
 import { chatToHtml, chatToMarkdown, chatToText } from "../lib/utils";
-import { type ChatData, ChatDataSchema, type ChatMessage } from "../schemas/chat";
+import { type ChatData, ChatDataSchema, type ChatMessage, type UserMap } from "../schemas/chat";
 import { Artifact } from "./Artifact";
 import { ConversationBrowser } from "./ConversationBrowser";
 import { JsonInput } from "./JsonInput";
@@ -950,6 +950,7 @@ const ChatViewer: React.FC = () => {
   const [fullErrorDetails, setFullErrorDetails] = useState<string | null>(null);
   const [isNavigating, setIsNavigating] = useState(false);
   const [useMasterDetail] = useState(true); // Default to master-detail view
+  const [userMap, setUserMap] = useState<UserMap | null>(null);
 
   // Update URL to reflect current state
   const updateURL = (
@@ -989,7 +990,8 @@ const ChatViewer: React.FC = () => {
     updateURL("view", data.uuid);
   };
 
-  const handleConversationList = (conversations: ChatData[], warning?: string) => {
+  const handleConversationList = (conversations: ChatData[], warning?: string, newUserMap?: UserMap) => {
+    setUserMap(newUserMap ?? null);
     setConversationList(conversations);
 
     if (warning) {
@@ -1514,6 +1516,7 @@ const ChatViewer: React.FC = () => {
                     updateURL("view", conversation.uuid);
                   }}
                   onBack={handleBackToInput}
+                  userMap={userMap ?? undefined}
                 >
                   {chatData && <ConversationView data={chatData} />}
                 </MasterDetailView>
@@ -1524,6 +1527,7 @@ const ChatViewer: React.FC = () => {
               conversations={conversationList}
               onSelectConversation={handleSelectFromBrowser}
               onBack={handleBackToInput}
+              userMap={userMap ?? undefined}
             />
           ) : activeTab === "view" && chatData ? (
             <ConversationView data={chatData} onBack={handleBackToInput} />

--- a/src/components/ConversationBrowser.tsx
+++ b/src/components/ConversationBrowser.tsx
@@ -17,7 +17,7 @@ export const ConversationBrowser: React.FC<ConversationBrowserProps> = ({
   conversations,
   onSelectConversation,
   onBack,
-  userMap: _userMap,
+  userMap,
 }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [searchMode, setSearchMode] = useState<"title" | "full">("full");
@@ -25,6 +25,32 @@ export const ConversationBrowser: React.FC<ConversationBrowserProps> = ({
   const [caseSensitive, setCaseSensitive] = useState(false);
   const [sortField, setSortField] = useState<SortField>("updated_at");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
+  const [selectedUserUuids, setSelectedUserUuids] = useState<Set<string>>(new Set());
+
+  const toggleUser = (uuid: string) => {
+    setSelectedUserUuids((prev) => {
+      const next = new Set(prev);
+      if (next.has(uuid)) {
+        next.delete(uuid);
+      } else {
+        next.add(uuid);
+      }
+      return next;
+    });
+  };
+
+  const usersWithCounts = useMemo(() => {
+    if (!userMap || userMap.size < 2) return [];
+    const countMap = new Map<string, number>();
+    for (const conversation of conversations) {
+      const uuid = (conversation as { account?: { uuid: string } }).account?.uuid;
+      if (uuid) countMap.set(uuid, (countMap.get(uuid) ?? 0) + 1);
+    }
+    return Array.from(userMap.values())
+      .filter((user) => countMap.has(user.uuid))
+      .sort((a, b) => (countMap.get(b.uuid) ?? 0) - (countMap.get(a.uuid) ?? 0))
+      .map((user) => ({ ...user, count: countMap.get(user.uuid) ?? 0 }));
+  }, [conversations, userMap]);
 
   const formatDate = (dateString: string) => {
     try {
@@ -49,13 +75,22 @@ export const ConversationBrowser: React.FC<ConversationBrowserProps> = ({
     // Sort conversations using the selected sort field and order
     const conversationsToFilter = sortConversations(conversations, sortField, sortOrder);
 
+    const userFiltered =
+      selectedUserUuids.size === 0
+        ? conversationsToFilter
+        : conversationsToFilter.filter((c) =>
+            selectedUserUuids.has(
+              (c as { account?: { uuid: string } }).account?.uuid ?? "",
+            ),
+          );
+
     if (!searchQuery.trim()) {
-      return { filteredConversations: conversationsToFilter, searchMatches: new Map() };
+      return { filteredConversations: userFiltered, searchMatches: new Map() };
     }
 
     const matchesMap = new Map<string, SearchMatch[]>();
 
-    const filtered = conversationsToFilter.filter((conversation) => {
+    const filtered = userFiltered.filter((conversation) => {
       try {
         let searchPattern: RegExp | string;
 
@@ -130,7 +165,7 @@ export const ConversationBrowser: React.FC<ConversationBrowserProps> = ({
     });
 
     return { filteredConversations: filtered, searchMatches: matchesMap };
-  }, [conversations, searchQuery, searchMode, useRegex, caseSensitive, sortField, sortOrder]);
+  }, [conversations, searchQuery, searchMode, useRegex, caseSensitive, sortField, sortOrder, selectedUserUuids]);
 
   return (
     <div className="max-w-6xl mx-auto p-6">
@@ -291,6 +326,40 @@ export const ConversationBrowser: React.FC<ConversationBrowserProps> = ({
           </label>
         </div>
       </div>
+
+      {usersWithCounts.length >= 2 && (
+        <div className="mb-6 space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-gray-700">Filter by user:</span>
+            {selectedUserUuids.size > 0 && (
+              <button
+                type="button"
+                onClick={() => setSelectedUserUuids(new Set())}
+                className="text-xs text-blue-600 hover:text-blue-800"
+              >
+                Clear filter
+              </button>
+            )}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {usersWithCounts.map((user) => (
+              <button
+                key={user.uuid}
+                type="button"
+                onClick={() => toggleUser(user.uuid)}
+                className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm border transition-colors ${
+                  selectedUserUuids.has(user.uuid)
+                    ? "bg-blue-100 border-blue-300 text-blue-800"
+                    : "bg-white border-gray-200 text-gray-700 hover:border-gray-300"
+                }`}
+              >
+                {user.full_name}
+                <span className="text-xs opacity-60">{user.count}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="grid gap-4">
         {filteredConversations.length === 0 ? (

--- a/src/components/ConversationBrowser.tsx
+++ b/src/components/ConversationBrowser.tsx
@@ -3,18 +3,21 @@ import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { findSearchMatches, type SearchMatch } from "../lib/searchUtils";
 import type { ChatData } from "../schemas/chat";
+import { type UserMap } from "../schemas/chat";
 import { sortConversations, type SortField, type SortOrder } from "../utils/sorting";
 
 interface ConversationBrowserProps {
   conversations: ChatData[];
   onSelectConversation: (conversation: ChatData) => void;
   onBack: () => void;
+  userMap?: UserMap;
 }
 
 export const ConversationBrowser: React.FC<ConversationBrowserProps> = ({
   conversations,
   onSelectConversation,
   onBack,
+  userMap: _userMap,
 }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [searchMode, setSearchMode] = useState<"title" | "full">("full");

--- a/src/components/ConversationBrowser.tsx
+++ b/src/components/ConversationBrowser.tsx
@@ -2,9 +2,8 @@ import { Calendar, ChevronLeft, Clock, Search, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { findSearchMatches, type SearchMatch } from "../lib/searchUtils";
-import type { ChatData } from "../schemas/chat";
-import { type UserMap } from "../schemas/chat";
-import { sortConversations, type SortField, type SortOrder } from "../utils/sorting";
+import type { ChatData, UserMap } from "../schemas/chat";
+import { type SortField, type SortOrder, sortConversations } from "../utils/sorting";
 
 interface ConversationBrowserProps {
   conversations: ChatData[];
@@ -79,9 +78,7 @@ export const ConversationBrowser: React.FC<ConversationBrowserProps> = ({
       selectedUserUuids.size === 0
         ? conversationsToFilter
         : conversationsToFilter.filter((c) =>
-            selectedUserUuids.has(
-              (c as { account?: { uuid: string } }).account?.uuid ?? "",
-            ),
+            selectedUserUuids.has((c as { account?: { uuid: string } }).account?.uuid ?? ""),
           );
 
     if (!searchQuery.trim()) {
@@ -165,7 +162,16 @@ export const ConversationBrowser: React.FC<ConversationBrowserProps> = ({
     });
 
     return { filteredConversations: filtered, searchMatches: matchesMap };
-  }, [conversations, searchQuery, searchMode, useRegex, caseSensitive, sortField, sortOrder, selectedUserUuids]);
+  }, [
+    conversations,
+    searchQuery,
+    searchMode,
+    useRegex,
+    caseSensitive,
+    sortField,
+    sortOrder,
+    selectedUserUuids,
+  ]);
 
   return (
     <div className="max-w-6xl mx-auto p-6">

--- a/src/components/ConversationBrowser.tsx
+++ b/src/components/ConversationBrowser.tsx
@@ -39,16 +39,18 @@ export const ConversationBrowser: React.FC<ConversationBrowserProps> = ({
   };
 
   const usersWithCounts = useMemo(() => {
-    if (!userMap || userMap.size < 2) return [];
     const countMap = new Map<string, number>();
     for (const conversation of conversations) {
       const uuid = (conversation as { account?: { uuid: string } }).account?.uuid;
       if (uuid) countMap.set(uuid, (countMap.get(uuid) ?? 0) + 1);
     }
-    return Array.from(userMap.values())
-      .filter((user) => countMap.has(user.uuid))
-      .sort((a, b) => (countMap.get(b.uuid) ?? 0) - (countMap.get(a.uuid) ?? 0))
-      .map((user) => ({ ...user, count: countMap.get(user.uuid) ?? 0 }));
+    if (countMap.size < 2) return [];
+    return Array.from(countMap.entries())
+      .sort((a, b) => b[1] - a[1])
+      .map(([uuid, count]) => {
+        const user = userMap?.get(uuid);
+        return { uuid, full_name: user?.full_name ?? `User ${uuid.slice(0, 8)}`, count };
+      });
   }, [conversations, userMap]);
 
   const formatDate = (dateString: string) => {

--- a/src/components/JsonInput.tsx
+++ b/src/components/JsonInput.tsx
@@ -598,9 +598,9 @@ export const JsonInput: React.FC<JsonInputProps> = ({ onValidJson, onConversatio
         try {
           const parsedData = JSON.parse(content);
 
-          // Build user map from users.json if present
+          // Build user map from users.json if present (used for name lookup)
           let userMap: UserMap | undefined;
-          const usersFile = zip.file("users.json");
+          const usersFile = zip.file(/(?:^|\/)users\.json$/)[0] ?? null;
           if (usersFile) {
             try {
               const usersContent = await usersFile.async("string");
@@ -613,8 +613,7 @@ export const JsonInput: React.FC<JsonInputProps> = ({ onValidJson, onConversatio
                     userMap.set(result.data.uuid, result.data);
                   }
                 }
-                // Discard map if it would only have 0 or 1 entries (no filter needed)
-                if (userMap.size < 2) userMap = undefined;
+                if (userMap.size === 0) userMap = undefined;
               }
             } catch {
               // silently ignore malformed users.json

--- a/src/components/JsonInput.tsx
+++ b/src/components/JsonInput.tsx
@@ -13,7 +13,7 @@ import sampleMath from "../data/sampleConversations/math-tutoring.json";
 // Import sample conversations
 import samplePython from "../data/sampleConversations/python.json";
 import sampleWebDev from "../data/sampleConversations/webdev.json";
-import { type ChatData, ChatDataSchema } from "../schemas/chat";
+import { type ChatData, ChatDataSchema, UserDataSchema, type UserMap } from "../schemas/chat";
 
 type ConversationOption = {
   name: string;
@@ -23,7 +23,7 @@ type ConversationOption = {
 
 interface JsonInputProps {
   onValidJson: (data: ChatData) => void;
-  onConversationList: (conversations: ChatData[], warning?: string) => void;
+  onConversationList: (conversations: ChatData[], warning?: string, userMap?: UserMap) => void;
 }
 
 // Helper function to extract readable error summary from Zod errors
@@ -154,7 +154,7 @@ export const JsonInput: React.FC<JsonInputProps> = ({ onValidJson, onConversatio
     }
   };
 
-  const processJsonData = (data: unknown) => {
+  const processJsonData = (data: unknown, userMap?: UserMap) => {
     // Handle array of conversations
     if (Array.isArray(data)) {
       if (data.length === 0) {
@@ -268,7 +268,7 @@ export const JsonInput: React.FC<JsonInputProps> = ({ onValidJson, onConversatio
           warningMsg = errorDetails.join("\n");
           console.log("Warning message being sent:", warningMsg);
         }
-        onConversationList(validConversations, warningMsg);
+        onConversationList(validConversations, warningMsg, userMap);
         setError(null);
         setOptions([]);
         return;
@@ -319,7 +319,7 @@ export const JsonInput: React.FC<JsonInputProps> = ({ onValidJson, onConversatio
           );
 
           const warningMsg = errorDetails.join("\n");
-          onConversationList(validConversations, warningMsg);
+          onConversationList(validConversations, warningMsg, userMap);
         } else {
           // Only one conversation and it's valid - show it directly
           onValidJson(validConversations[0]);
@@ -597,7 +597,31 @@ export const JsonInput: React.FC<JsonInputProps> = ({ onValidJson, onConversatio
 
         try {
           const parsedData = JSON.parse(content);
-          processJsonData(parsedData);
+
+          // Build user map from users.json if present
+          let userMap: UserMap | undefined;
+          const usersFile = zip.file("users.json");
+          if (usersFile) {
+            try {
+              const usersContent = await usersFile.async("string");
+              const usersRaw = JSON.parse(usersContent);
+              if (Array.isArray(usersRaw)) {
+                userMap = new Map();
+                for (const entry of usersRaw) {
+                  const result = UserDataSchema.safeParse(entry);
+                  if (result.success) {
+                    userMap.set(result.data.uuid, result.data);
+                  }
+                }
+                // Discard map if it would only have 0 or 1 entries (no filter needed)
+                if (userMap.size < 2) userMap = undefined;
+              }
+            } catch {
+              // silently ignore malformed users.json
+            }
+          }
+
+          processJsonData(parsedData, userMap);
         } catch (err) {
           if (err instanceof Error) {
             setError(`Invalid JSON in ZIP file: ${err.message}`);

--- a/src/components/MasterDetailView.tsx
+++ b/src/components/MasterDetailView.tsx
@@ -2,9 +2,8 @@ import { Calendar, ChevronLeft, PanelLeft, PanelLeftClose, Search, X } from "luc
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { findSearchMatches, type SearchMatch } from "../lib/searchUtils";
-import type { ChatData } from "../schemas/chat";
-import { type UserMap } from "../schemas/chat";
-import { sortConversations, type SortField, type SortOrder } from "../utils/sorting";
+import type { ChatData, UserMap } from "../schemas/chat";
+import { type SortField, type SortOrder, sortConversations } from "../utils/sorting";
 
 interface MasterDetailViewProps {
   conversations: ChatData[];
@@ -94,9 +93,7 @@ export const MasterDetailView: React.FC<MasterDetailViewProps> = ({
       selectedUserUuids.size === 0
         ? sortedConversations
         : sortedConversations.filter((c) =>
-            selectedUserUuids.has(
-              (c as { account?: { uuid: string } }).account?.uuid ?? "",
-            ),
+            selectedUserUuids.has((c as { account?: { uuid: string } }).account?.uuid ?? ""),
           );
 
     if (!searchQuery.trim()) {

--- a/src/components/MasterDetailView.tsx
+++ b/src/components/MasterDetailView.tsx
@@ -44,16 +44,18 @@ export const MasterDetailView: React.FC<MasterDetailViewProps> = ({
   };
 
   const usersWithCounts = useMemo(() => {
-    if (!userMap || userMap.size < 2) return [];
     const countMap = new Map<string, number>();
     for (const conversation of conversations) {
       const uuid = (conversation as { account?: { uuid: string } }).account?.uuid;
       if (uuid) countMap.set(uuid, (countMap.get(uuid) ?? 0) + 1);
     }
-    return Array.from(userMap.values())
-      .filter((user) => countMap.has(user.uuid))
-      .sort((a, b) => (countMap.get(b.uuid) ?? 0) - (countMap.get(a.uuid) ?? 0))
-      .map((user) => ({ ...user, count: countMap.get(user.uuid) ?? 0 }));
+    if (countMap.size < 2) return [];
+    return Array.from(countMap.entries())
+      .sort((a, b) => b[1] - a[1])
+      .map(([uuid, count]) => {
+        const user = userMap?.get(uuid);
+        return { uuid, full_name: user?.full_name ?? `User ${uuid.slice(0, 8)}`, count };
+      });
   }, [conversations, userMap]);
 
   // Auto-collapse sidebar on mobile by default

--- a/src/components/MasterDetailView.tsx
+++ b/src/components/MasterDetailView.tsx
@@ -1,8 +1,9 @@
 import { Calendar, ChevronLeft, PanelLeft, PanelLeftClose, Search, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { findSearchMatches, type SearchMatch } from "../lib/searchUtils";
 import type { ChatData } from "../schemas/chat";
+import { type UserMap } from "../schemas/chat";
 import { sortConversations, type SortField, type SortOrder } from "../utils/sorting";
 
 interface MasterDetailViewProps {
@@ -11,6 +12,7 @@ interface MasterDetailViewProps {
   onSelectConversation: (conversation: ChatData) => void;
   onBack: () => void;
   children: React.ReactNode;
+  userMap?: UserMap;
 }
 
 export const MasterDetailView: React.FC<MasterDetailViewProps> = ({
@@ -19,6 +21,7 @@ export const MasterDetailView: React.FC<MasterDetailViewProps> = ({
   onSelectConversation,
   onBack,
   children,
+  userMap,
 }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [searchMode, setSearchMode] = useState<"title" | "full">("full");
@@ -27,6 +30,32 @@ export const MasterDetailView: React.FC<MasterDetailViewProps> = ({
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [sortField, setSortField] = useState<SortField>("updated_at");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
+  const [selectedUserUuids, setSelectedUserUuids] = useState<Set<string>>(new Set());
+
+  const toggleUser = (uuid: string) => {
+    setSelectedUserUuids((prev) => {
+      const next = new Set(prev);
+      if (next.has(uuid)) {
+        next.delete(uuid);
+      } else {
+        next.add(uuid);
+      }
+      return next;
+    });
+  };
+
+  const usersWithCounts = useMemo(() => {
+    if (!userMap || userMap.size < 2) return [];
+    const countMap = new Map<string, number>();
+    for (const conversation of conversations) {
+      const uuid = (conversation as { account?: { uuid: string } }).account?.uuid;
+      if (uuid) countMap.set(uuid, (countMap.get(uuid) ?? 0) + 1);
+    }
+    return Array.from(userMap.values())
+      .filter((user) => countMap.has(user.uuid))
+      .sort((a, b) => (countMap.get(b.uuid) ?? 0) - (countMap.get(a.uuid) ?? 0))
+      .map((user) => ({ ...user, count: countMap.get(user.uuid) ?? 0 }));
+  }, [conversations, userMap]);
 
   // Auto-collapse sidebar on mobile by default
   useEffect(() => {
@@ -61,13 +90,22 @@ export const MasterDetailView: React.FC<MasterDetailViewProps> = ({
     // Sort conversations using the selected sort field and order
     const sortedConversations = sortConversations(conversations, sortField, sortOrder);
 
+    const userFiltered =
+      selectedUserUuids.size === 0
+        ? sortedConversations
+        : sortedConversations.filter((c) =>
+            selectedUserUuids.has(
+              (c as { account?: { uuid: string } }).account?.uuid ?? "",
+            ),
+          );
+
     if (!searchQuery.trim()) {
-      return { filteredConversations: sortedConversations, searchMatches: new Map() };
+      return { filteredConversations: userFiltered, searchMatches: new Map() };
     }
 
     const matchesMap = new Map<string, SearchMatch[]>();
 
-    const filtered = sortedConversations.filter((conversation) => {
+    const filtered = userFiltered.filter((conversation) => {
       try {
         let searchPattern: RegExp | string;
 
@@ -306,6 +344,43 @@ export const MasterDetailView: React.FC<MasterDetailViewProps> = ({
                 </label>
               </div>
             </div>
+
+            {/* User Filter */}
+            {usersWithCounts.length >= 2 && (
+              <div className="mt-3 pt-3 border-t border-gray-200 space-y-1">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium text-gray-700">Filter by user:</span>
+                  {selectedUserUuids.size > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => setSelectedUserUuids(new Set())}
+                      className="text-xs text-blue-600 hover:text-blue-800"
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+                <div className="space-y-1 max-h-40 overflow-y-auto">
+                  {usersWithCounts.map((user) => (
+                    <label
+                      key={user.uuid}
+                      className="flex items-center gap-2 cursor-pointer py-0.5"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedUserUuids.has(user.uuid)}
+                        onChange={() => toggleUser(user.uuid)}
+                        className="w-3 h-3 rounded border-gray-300 flex-shrink-0"
+                      />
+                      <span className="text-xs text-gray-700 truncate flex-1">
+                        {user.full_name}
+                      </span>
+                      <span className="text-xs text-gray-400 flex-shrink-0">{user.count}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/schemas/chat.test.ts
+++ b/src/schemas/chat.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
-import { ChatDataSchema } from "./chat";
+import { ChatDataSchema, UserDataSchema } from "./chat";
 
 describe("ChatDataSchema", () => {
   test("should parse conversation with artifacts format", () => {
@@ -184,5 +184,48 @@ describe("ChatDataSchema", () => {
         expect(lastContent.text).toBe("Some text after");
       }
     }
+  });
+});
+
+describe("UserDataSchema", () => {
+  test("validates a full user entry", () => {
+    const result = UserDataSchema.safeParse({
+      uuid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      full_name: "Test User",
+      email_address: "test@example.com",
+      verified_phone_number: "+1234567890",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.full_name).toBe("Test User");
+      expect(result.data.uuid).toBe("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    }
+  });
+
+  test("validates without optional fields", () => {
+    const result = UserDataSchema.safeParse({
+      uuid: "abc-123",
+      full_name: "Jana Nováková",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("fails when full_name is missing", () => {
+    const result = UserDataSchema.safeParse({ uuid: "abc-123" });
+    expect(result.success).toBe(false);
+  });
+
+  test("fails when uuid is missing", () => {
+    const result = UserDataSchema.safeParse({ full_name: "Someone" });
+    expect(result.success).toBe(false);
+  });
+
+  test("passes through unknown fields", () => {
+    const result = UserDataSchema.safeParse({
+      uuid: "abc",
+      full_name: "Test",
+      future_field: "value",
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/src/schemas/chat.ts
+++ b/src/schemas/chat.ts
@@ -209,8 +209,8 @@ export const UserDataSchema = z
   .object({
     uuid: z.string(),
     full_name: z.string(),
-    email_address: z.string().optional(),
-    verified_phone_number: z.string().optional(),
+    email_address: z.string().nullable().optional(),
+    verified_phone_number: z.string().nullable().optional(),
   })
   .passthrough();
 

--- a/src/schemas/chat.ts
+++ b/src/schemas/chat.ts
@@ -204,6 +204,19 @@ const SettingsSchema = z.object({
   enabled_turmeric: z.boolean().optional(),
 });
 
+// Schema for users.json entries
+export const UserDataSchema = z
+  .object({
+    uuid: z.string(),
+    full_name: z.string(),
+    email_address: z.string().optional(),
+    verified_phone_number: z.string().optional(),
+  })
+  .passthrough();
+
+export type UserData = z.infer<typeof UserDataSchema>;
+export type UserMap = Map<string, UserData>; // keyed by account uuid
+
 // Schema for individual conversation exports
 const IndividualChatSchema = z
   .object({

--- a/src/utils/sorting.ts
+++ b/src/utils/sorting.ts
@@ -1,7 +1,7 @@
-import type { ChatData } from '../schemas/chat';
+import type { ChatData } from "../schemas/chat";
 
-export type SortField = 'created_at' | 'updated_at';
-export type SortOrder = 'asc' | 'desc';
+export type SortField = "created_at" | "updated_at";
+export type SortOrder = "asc" | "desc";
 
 export interface SortConfig {
   field: SortField;
@@ -19,13 +19,13 @@ export interface SortConfig {
 export function sortConversations(
   conversations: ChatData[],
   field: SortField,
-  order: SortOrder
+  order: SortOrder,
 ): ChatData[] {
   return [...conversations].sort((a, b) => {
     const dateA = new Date(a[field]).getTime();
     const dateB = new Date(b[field]).getTime();
 
-    if (order === 'asc') {
+    if (order === "asc") {
       return dateA - dateB; // Ascending: oldest first
     }
     return dateB - dateA; // Descending: newest first
@@ -37,10 +37,10 @@ export function sortConversations(
  */
 export function getSortFieldLabel(field: SortField): string {
   switch (field) {
-    case 'created_at':
-      return 'Created';
-    case 'updated_at':
-      return 'Modified';
+    case "created_at":
+      return "Created";
+    case "updated_at":
+      return "Modified";
   }
 }
 
@@ -48,5 +48,5 @@ export function getSortFieldLabel(field: SortField): string {
  * Gets a human-readable label for a sort order.
  */
 export function getSortOrderLabel(order: SortOrder): string {
-  return order === 'asc' ? 'Oldest First' : 'Newest First';
+  return order === "asc" ? "Oldest First" : "Newest First";
 }


### PR DESCRIPTION
## Summary

- Adds a **user filter** to both the sidebar (MasterDetailView) and the browse view (ConversationBrowser) that appears automatically when an organization export is loaded
- Derives the user list from distinct `account.uuid` values in `conversations.json`; uses `users.json` for name lookup where available, falls back to `User <uuid-prefix>` when not
- Filter is **multi-select**: no selection shows all conversations; selecting one or more users narrows the list (AND logic with existing text search)
- **Invisible for personal exports** (single account UUID → filter not shown) and for old exports without `users.json`
- Fixes `UserDataSchema` to accept `null` for `verified_phone_number` and `email_address` (org exports set these to JSON `null` for most users)
- Extends `onConversationList` callback with an optional `userMap?: UserMap` parameter (backward compatible)

## Behavior

| Scenario | users.json present | Distinct account UUIDs | Filter shown |
|---|---|---|---|
| Personal export | Yes (1 user) | 1 | No |
| Org export | Yes (N users) | 2+ | Yes |
| Old export | No | — | No |

## Test plan

- [x] Load a personal export ZIP → no user filter visible, all conversations shown as before
- [x] Load an organization export ZIP with multiple users → user filter appears with names sorted by conversation count
- [x] Select one user → list narrows to that user's conversations
- [x] Select multiple users → list shows conversations from all selected users
- [x] Combine user filter with text search → both filters apply simultaneously
- [x] Clear filter button resets selection
- [x] Load a second ZIP → user filter resets (no stale selection from previous load)
- [x] `bun run check` passes (typecheck + lint)
- [x] `bun test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)